### PR TITLE
Add instuctions for The Swisscom Application Cloud

### DIFF
--- a/basics/site/content/labs/cli.md
+++ b/basics/site/content/labs/cli.md
@@ -34,9 +34,9 @@ cf <some-command> --help
 ## Log In
 
 You can use the CLI to log into any Cloud Foundry you have an account in.
-
-{{% do %}}Use `cf help -a` to find out how to login to Pivotal Web Services. The API endpoint you need is `api.run.pivotal.io`.{{% /do %}}
-{{% question %}}Are you logged into Pivotal Web Services?{{% /question %}}
+`
+{{% do %}}Use `cf help -a` to find out how to login to Pivotal Web Services/The Swisscom Application Cloud. The API endpoint you need for Pivotal Web Services is `api.run.pivotal.io`, or for The Swisscom Application Cloud use the endpoint `api.lyra-836.appcloud.swisscom.com` .{{% /do %}}
+{{% question %}}Are you logged into Pivotal Web Services/The Swisscom Application Cloud?{{% /question %}}
 {{% question %}}What org and space are you targeting?{{% /question %}}
 
 {{% checking %}}
@@ -44,7 +44,7 @@ You can use the CLI to log into any Cloud Foundry you have an account in.
 You can see where you are logged in using `cf target`. You should see something similar to:
 
 ```sh
-API endpoint:   https://api.run.pivotal.io
+API endpoint:   https://api.endpoint.io
 API version:    2.78.0
 User:           me@example.com
 Org:            my-org

--- a/basics/site/content/labs/new-account.md
+++ b/basics/site/content/labs/new-account.md
@@ -1,20 +1,29 @@
 ---
 date: 2016-04-19T19:21:15-06:00
-title: Sign Up - Pivotal Web Services
+title: Sign Up - Pivotal Web Services or Swisscom Application Cloud
 ---
 
-For this class, we will use the Cloud Foundry running on Pivotal Web Services. You must have an account to continue.
+For this class, we will use the Cloud Foundry running on either Pivotal Web Services or The Swisscom Application Cloud.
+
+Your instructor will guide you on which service to use.
+
+You must have an account to continue.
 
 ## Sign Up
 
+### Pivotal Web Services 
 {{% do %}}Sign up by going to [https://run.pivotal.io/](https://run.pivotal.io/){{% /do %}}
 
+-- or --
+
+### Swisscom Application Cloud
+{{% do %}}Sign up by going to [https://cf-summit-registration.scapp.io/](https://cf-summit-registration.scapp.io/){{% /do %}}
 
 ## Beyond the Class
 
 Compare CF public services:
 
   * [Anynines](http://www.anynines.com/)
-  * [Swisscom](https://developer.swisscom.com/)
   * [IBM Bluemix](https://console.ng.bluemix.net/)
   * [Pivotal Web Services](https://run.pivotal.io/)
+  * [Swisscom](https://developer.swisscom.com/)

--- a/basics/site/content/labs/pushing.md
+++ b/basics/site/content/labs/pushing.md
@@ -72,7 +72,7 @@ applications:
 
 ### Random Route
 
-The app deploys using `random-route`.  Since the `cfapps.io` is shared by all [run.pivotal.io](https://run.pivotal.io/) apps, we need an easy way to deploy our app to this shared domain for development.
+The app deploys using `random-route`.  Since the `cfapps.io` is shared by all [run.pivotal.io](https://run.pivotal.io/) apps, we need an easy way to deploy our app to this shared domain for development.  If you are using The Swisscom Application  Cloud, the shared domain will be `scapp.io`.
 
 You can see the details on `random-route` using cf help:
 

--- a/basics/site/content/labs/routes.md
+++ b/basics/site/content/labs/routes.md
@@ -10,7 +10,7 @@ In this exercise, you will use route mapping to perform a zero-downtime upgrade 
 
 We need to create a route for the app we are going to deploy. This route will be used for _all_ versions of the app, so should stay the same even when the app is updated.
 
-{{% do %}}Use `cf create-route` to a create a new route for your app, making sure the domain is `cfapps.io`{{% /do %}}
+{{% do %}}Use `cf create-route` to a create a new route for your app, making sure the domain is `cfapps.io` if you are using Pivotal Web Services, or `scapp.io` if you are using The Swisscom Application Cloud{{% /do %}}
 
 ### Push v1.0
 

--- a/basics/site/content/labs/state.md
+++ b/basics/site/content/labs/state.md
@@ -10,7 +10,7 @@ In this lab,  you will create an instance of a Redis service and use it with an 
 First, you need to create an instance of the service.
 
 {{% do %}}Use `cf marketplace` to view the details of the Redis service{{% /do %}}
-{{% do %}}Use the CLI to create an instance of the `30mb` plan{{% /do %}}
+{{% do %}}Use the CLI to create an instance of the `30mb` plan for Pivotal Web Services or the `free` plan on The Swisscom Application Cloud{{% /do %}}
 {{% do %}}Use `cf help -a` to find command to list the services in your space{{% /do %}}
 
 {{% checking %}}
@@ -21,6 +21,8 @@ You should see something similar to:
 name    service      plan   bound apps   last operation
 redis   rediscloud   30mb                create succeeded
 ```
+
+Note: On The Swisscom Application Cloud, the Redis service is called `redis`, not `rediscloud`.
 {{% /checking %}}
 
 ## Bind a Service Instance


### PR DESCRIPTION
For Cloud Foundry Summit 2017 in Santa Clara, The Swisscom Application
Cloud will be used instead of Pivotal Web Services.  After discussion
with @tharrisca, it was decided to modify the existing labs with
instructions for Swisscom alongside PWS.