### PR TITLE
Instructor notes, buildpack updates, removed value statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 public/
 .DS_Store
 **/credentials.yml
+
+basics/ci/custom-vars.yml
+
 operator/terraform/.terraform
 operator/terraform/students.json
 operator/terraform/terraform.tfstate*

--- a/basics/README.md
+++ b/basics/README.md
@@ -1,5 +1,7 @@
 # Cloud Foundry Foundation basics training
 
+If you're delivering the course, please review the [delivery guidelines](delivery.md) and the [slide notes](slides/README.md).
+
 ## Prerequisites for building sites/slides
 * [Hugo](https://gohugo.io/)
 

--- a/basics/ci/README.md
+++ b/basics/ci/README.md
@@ -1,0 +1,31 @@
+# CI/CD
+
+## Setting the pipeline
+
+Target and log in to your Concourse then set the pipeline with
+
+```sh
+fly -t YOUR_CONCOURSE set-pipeline \
+    --pipeline basics-course \
+    --config pipeline.yml \
+    --load-vars-from pipeline-vars.yml
+```
+
+When setting your pipeline you must also make sure the following values are available either by passing them with `--var` in the command above or by putting them in your Concourse's credential manager (i.e. Credhub/Vault/etc)
+
+```yaml
+cf-api
+cf-username
+cf-password
+cf-org
+cf-space
+```
+
+Note if you want to pull from a fork rather than from the CFF repo, create your own `custom-vars.yml` file with:
+
+```yaml
+course-repository: YOUR_FORK
+routes: '[route: a-custom-route.example.com]'
+```
+
+Then set the pipeline using that instead of `pipeline-vars.yml`

--- a/basics/ci/manifest.yml
+++ b/basics/ci/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: basics-workshop
-  buildpack: staticfile_buildpack
+  buildpacks:
+  - staticfile_buildpack
   routes:
     ((routes))

--- a/basics/ci/manifest.yml
+++ b/basics/ci/manifest.yml
@@ -2,3 +2,5 @@
 applications:
 - name: basics-workshop
   buildpack: staticfile_buildpack
+  routes:
+    ((routes))

--- a/basics/ci/pipeline-vars.yml
+++ b/basics/ci/pipeline-vars.yml
@@ -1,0 +1,3 @@
+course-repository: https://github.com/cloudfoundry/summit-training-classes.git
+routes-file: routes.yml
+routes: '[route: basics-workshop.cloudfoundry.org]'

--- a/basics/ci/pipeline.yml
+++ b/basics/ci/pipeline.yml
@@ -1,4 +1,19 @@
----
+resources:
+- name: summit-training-classes
+  type: git
+  source:
+    branch: master
+    uri: ((course-repository))
+- name: cf
+  type: cf
+  source:
+    api: ((cf-api))
+    organization: ((cf-org))
+    password: ((cf-password))
+    skip_cert_check: false
+    space: ((cf-space))
+    username: ((cf-username))
+
 jobs:
 - name: publish
   public: true
@@ -11,19 +26,5 @@ jobs:
     params:
       manifest: summit-training-classes/basics/ci/manifest.yml
       path: built/
-
-resources:
-- name: summit-training-classes
-  type: git
-  source:
-    uri: https://github.com/cloudfoundry/summit-training-classes.git
-    branch: master
-- name: cf
-  type: cf
-  source:
-    api: https://api.run.pivotal.io
-    username: systems@engineerbetter.com
-    password: {{cf-password}}
-    organization: engineerbetter
-    space: {{cf-space}}
-    skip_cert_check: false
+      vars:
+        routes: ((routes))

--- a/basics/delivery.md
+++ b/basics/delivery.md
@@ -1,0 +1,56 @@
+# Delivering The Course
+
+## Material Philosophy
+
+This course is designed to educate students via hands-on experience.
+
+## Structure
+
+The course should last no more than a single day, and a typical delivery looks thus:
+
+* Introductions
+* For each module:
+  * Slides
+  * Lab
+  * Recap
+* Retrospective
+
+### Introductions
+
+You may want to ask individuals to introduce themselves, what they want to get out of the day (so you can help them more effectively) and maybe some sort of icebreaker question.
+
+Additionally students should be shown to the course site, and provided any credentials necessary.
+
+### Slides
+
+Slides exist to introduce concepts and explain background information. **Slides should _not_ feature excessive implementation detail**, as this will not be remembered by students and will also become out of date very quickly.
+
+The slides are intentionally light on diagrams, knowing that these will instead be produced ad-hoc by the instructor in recaps.
+
+### Labs
+
+**Labs give students hands-on experience**. Students are encouraged to use the official documentation and self-documenting tools (like the CF CLI) which will always be accurate and contemporary. Additionally this teaches the students to become self-sufficient.
+
+**Labs should not include answers**. Students should not be able to complete exercises only by copy/pasting.
+
+Labs should **make it clear** to students **when they have done the right thing**.
+
+Students should be encouraged to help each other; humans learn better in social environments.
+
+The **labs do not build upon one another**, hence if labs have to be abandoned due to time constraints this will not impact later exercises.
+
+### Recaps
+
+Interactive recap sessions should be held after each module where appropriate. The instructor should **gather the students around a whiteboard** and ask them a series of questions about the lab exercises they just completed. For example:
+
+* What did you just do?
+* What does the CLI talk to?
+* How does the CLI remember who you are?
+
+As each question is answered, the instructor draws relevant components of Cloud Foundry on the whiteboard. Be careful to not fall into the trap of explaining without first answering questions: people are more likely to remember information if they were asked about it previously - even if when asked they had no chance of knowing the answer!
+
+The recap sessions further cement knowledge in the students, allow the instructor to drill into details upon request, and also allow the instructor to gauge how much of the prior material has been understood.
+
+### Retrospective
+
+An **agile retrospective should be held at the end of the day**, to highlight areas of improvement for the instructor(s) and the course, and allow students vent any frustrations they may have had.

--- a/basics/site/README.md
+++ b/basics/site/README.md
@@ -127,3 +127,17 @@ _Resolution:_ Make sure to explain that they can name the service instance whate
 Sometimes service provisioning has been observed to time out after 10 minutes. The operation cannot be cancelled.
 
 _Resolution:_ Contact Swisscom if this issue is seen, and the only option is to wait.
+
+## 8. Routes
+
+### Common Issues
+
+#### Arguments in the wrong order
+
+The argument order in `cf create-route` and `cf map-route` are counter-intuitive:
+
+`cf create-route space domain.com --hostname www`
+
+The thing that usually appears on the left (`www`) appears on the right in the command, and the command misuses terminology.
+
+_Resolution:_ Explicitly highlight this confusing issue on a white board.

--- a/basics/site/README.md
+++ b/basics/site/README.md
@@ -1,0 +1,37 @@
+# Lab Instructor Notes
+
+This document collates notes on the course exercises.
+
+## 1. Sign Up - Pivotal Web Services or Swisscom Application Cloud
+
+### Common Issues
+
+#### Network connectivity
+
+As this is the first lab, this is when you discover that PWS is blocked by a corporate proxy!
+
+_Resolution:_ Tether (everyone) to a mobile device or contact network administrators.
+
+#### Existing accounts
+
+Students may have work accounts, and then ignore instructions to create a new one, or accidentally use the wrong account.
+
+_Resolution:_ Log out of everything, create a new browser user profile, or use private browsing sessions.
+
+#### PWS activation emails expiring
+
+They can only be viewed once, and if you sign up for a new account in a private window, and then try verifying your account in a window logged into another account, your activation will expire.
+
+_Resolution:_ It may be easier to use instructor-provisioned accounts (see the `scripts` directory).
+
+#### PWS requires SMS verification
+
+This can be an issue when teaching an international audience (eg at a conference).
+
+_Resolution:_ It may be easier to use instructor-provisioned accounts (see the `scripts` directory).
+
+#### Swisscom web UI slowing down
+
+The Swisscom web UI for sign-up has been known to slow down when an entire class has hit it at once.
+
+_Resolution:_ It may be easier to use instructor-provisioned accounts (see the `scripts` directory), although this has only been tried for PWS.

--- a/basics/site/README.md
+++ b/basics/site/README.md
@@ -35,3 +35,25 @@ _Resolution:_ It may be easier to use instructor-provisioned accounts (see the `
 The Swisscom web UI for sign-up has been known to slow down when an entire class has hit it at once.
 
 _Resolution:_ It may be easier to use instructor-provisioned accounts (see the `scripts` directory), although this has only been tried for PWS.
+
+## 2. CLI Basics
+
+### Common Issues
+
+#### Unable to install software
+
+Windows users often have their permissions limited, preventing them from installing the CLI.
+
+_Resolution:_ Pair with another student. The ability to install software is a class pre-requisite.
+
+#### Account lock-outs
+
+The UAA will lock an account if the wrong password is used three times in succession.
+
+_Resolution:_ Wait an unspecified amount of time (try again after the next slides), or use an instructor-provided account.
+
+#### Immediate login failure
+
+An unexplained issue has been observed on Windows machines whereby the CLI will fail on `cf login` with an authentication issue without even prompting for a username/password.
+
+_Resolution:_ Delete the contents of the `~/.cf` directory.

--- a/basics/site/README.md
+++ b/basics/site/README.md
@@ -57,3 +57,25 @@ _Resolution:_ Wait an unspecified amount of time (try again after the next slide
 An unexplained issue has been observed on Windows machines whereby the CLI will fail on `cf login` with an authentication issue without even prompting for a username/password.
 
 _Resolution:_ Delete the contents of the `~/.cf` directory.
+
+## 3. Pushing Your First App
+
+### Common Issues
+
+#### Being in the wrong directory
+
+Many users are command-line novices, and end up pushing from the wrong directory. Symptoms will be either the CLI unexpectedly asking for an app name (because there is no manifest in the directory), or incredibly slow pushes (because the CLI is trying to upload the user's entire home directory).
+
+_Resolution:_ Draw common filesystem navigation commands on the whiteboard.
+
+#### Wrong version of the CLI
+
+The symptoms of this are typically errors about unknown flags. If you seen unexpected behaviour, check the user's CLI version.
+
+_Resolution:_ Ensure the student has the latest CF CLI release.
+
+#### Users getting stuck tailing logs
+
+Users may run `cf logs` which tails, and either think it hasn't worked because an app isn't logging, or may not know how to exit.
+
+_Resolution:_ CTRL+C

--- a/basics/site/README.md
+++ b/basics/site/README.md
@@ -102,3 +102,12 @@ _Resolution:_ Draw common filesystem navigation commands on the whiteboard; disc
 
 This lab tends to go smoothly - the only likely problems are to do with pushing apps from the wrong directory.
 
+## 6. Debugging
+
+### Common Issues
+
+#### New Relic data takes a long time to appear
+
+Sometimes data and charts don't appear in the New Relic dashboard in a timely fashion.
+
+_Resolution:_ Wait, or move on. It shouldn't take more than a few minutes, and certainly not more than fifteen.

--- a/basics/site/README.md
+++ b/basics/site/README.md
@@ -95,3 +95,10 @@ _Resolution:_ None needed.
 Novice command-line users may need some help navigating the filesystem, and an explanation of what the files present _mean_.
 
 _Resolution:_ Draw common filesystem navigation commands on the whiteboard; discuss file differences in the recap.
+
+## 5. Availability
+
+### Common Issues
+
+This lab tends to go smoothly - the only likely problems are to do with pushing apps from the wrong directory.
+

--- a/basics/site/README.md
+++ b/basics/site/README.md
@@ -92,6 +92,8 @@ _Resolution:_ CTRL+C
 
 ## 4. Buildpacks
 
+Students who aren't particularly technical may not get so much benefit from this exercise, and will need extra guidance to recognise the value provided by buildpacks.
+
 ### Answers
 
 #### If you don’t specify a buildpack, what is the first one that will be tested for?
@@ -150,6 +152,8 @@ This lab tends to go smoothly - the only likely problems are to do with pushing 
 
 ## 6. Debugging
 
+If the New Relic section is attempted, this is likely the longest lab of the course.
+
 ### Answers
 
 #### What does Cloud Foundry think the health of the app is? How did it draw this conclusion?
@@ -173,6 +177,8 @@ Sometimes data and charts don't appear in the New Relic dashboard in a timely fa
 _Resolution:_ Wait, or move on. It shouldn't take more than a few minutes, and certainly not more than fifteen.
 
 ## 7. Dealing with State
+
+This lab has many steps, and as a result is one of the longer ones.
 
 ### Answers
 
@@ -207,6 +213,8 @@ Sometimes service provisioning has been observed to time out after 10 minutes. T
 _Resolution:_ Contact Swisscom if this issue is seen, and the only option is to wait.
 
 ## 8. Routes
+
+This exercise is often quite long, and students are confused by the route-mapping. It may help to draw the route-mapping on a whiteboard, linking routes and apps with arrows.
 
 ### Answers
 

--- a/basics/site/README.md
+++ b/basics/site/README.md
@@ -60,6 +60,16 @@ _Resolution:_ Delete the contents of the `~/.cf` directory.
 
 ## 3. Pushing Your First App
 
+### Answers
+
+#### How can you access your web app?
+
+Open the URL in a web browser.
+
+#### What differences are there in the manifest? Why are these needed?
+
+`no-route: true`, to prevent Diego from treating the app as a web app and marking it as crashed for not listening on `$PORT`.
+
 ### Common Issues
 
 #### Being in the wrong directory
@@ -82,6 +92,32 @@ _Resolution:_ CTRL+C
 
 ## 4. Buildpacks
 
+### Answers
+
+#### If you don’t specify a buildpack, what is the first one that will be tested for?
+
+The one at the top of the list.
+
+#### How can you check that you pushed your app successfully?
+
+Access it in a browser, or use `cf app`.
+
+#### How does the running droplet compare to your app directory?
+
+Amongst other things, it moves the `index.html` file and adds NGiNX and associated config.
+
+#### Why is CF able to scale instances so quickly?
+
+Because the droplet is already built, and possibly already exists in the cache of each Diego cell.
+
+#### Which buildpack do you think will be used to run this app? Staticfile, or PHP?
+
+Whichever of the two is higher in the list.
+
+#### What happens this time? Why?
+
+NGiNX doesn't understand how to render PHP, so sends headers that prompt the browser to treat it as a file download.
+
 ### Common Issues
 
 #### `cf ssh` appearing to hang on Windows
@@ -98,11 +134,35 @@ _Resolution:_ Draw common filesystem navigation commands on the whiteboard; disc
 
 ## 5. Availability
 
+### Answers
+
+#### Can you see it in the “crashed” state before Cloud Foundry restarts it?
+
+Probably not. If Diego is having a good day, on the first crash, it should restart the app almost immediately.
+
+#### What happens if you make a request whilst they are all down?
+
+The GoRouter returns a 404.
+
 ### Common Issues
 
 This lab tends to go smoothly - the only likely problems are to do with pushing apps from the wrong directory.
 
 ## 6. Debugging
+
+### Answers
+
+#### What does Cloud Foundry think the health of the app is? How did it draw this conclusion?
+
+Cloud Foundry thinks the app is healthy, because the default healthcheck is merely to check that the app is listening on the given port. It is likely that we will want to know if our web app is only returning 500 errors, hence the change to a HTTP-based healthcheck.
+
+#### How do the two compare? What help does Cloud Foundry give you in determining the cause of failure?
+
+The events should differ based on the nature of the crash; however the exact output differs as Garden/Diego change.
+
+#### What happens? Is this what you expected?
+
+Exhausting the disk does _not_ immediately crash an app. It is considered a recoverable situation, so the platform does not terminate the app. The app may, however, crash of its own accord by merit of having no disk space.
 
 ### Common Issues
 
@@ -113,6 +173,24 @@ Sometimes data and charts don't appear in the New Relic dashboard in a timely fa
 _Resolution:_ Wait, or move on. It shouldn't take more than a few minutes, and certainly not more than fifteen.
 
 ## 7. Dealing with State
+
+### Answers
+
+#### Does this work immediately? If not, why not? What commands can you use to find out more?
+
+No. The app needs to be started, but the CLI will ask the user to restage, which will fail because the app has never staged. Neither the CLI nor CAPI team wanted to fix this behaviour when asked.
+
+#### What commands can you use to tell if you’ve bound the service instance to the correct app?
+
+`cf services` is the easiest answer.
+
+#### What will happen when we unbind the app?
+
+No data is lost.
+
+#### Can you use cf delete-service redis?
+
+No, as it is still bound to the app. Unbind it first.
 
 ### Common Issues
 
@@ -129,6 +207,16 @@ Sometimes service provisioning has been observed to time out after 10 minutes. T
 _Resolution:_ Contact Swisscom if this issue is seen, and the only option is to wait.
 
 ## 8. Routes
+
+### Answers
+
+#### Does the push work? If not, why not? Can you fix this with a commandline argument?
+
+No, as the route is probably already-taken. The student should use the `--random-route` functionality.
+
+#### Could you leave the v1.0 app running in case you need to roll-back?
+
+Yes.
 
 ### Common Issues
 

--- a/basics/site/README.md
+++ b/basics/site/README.md
@@ -111,3 +111,19 @@ This lab tends to go smoothly - the only likely problems are to do with pushing 
 Sometimes data and charts don't appear in the New Relic dashboard in a timely fashion.
 
 _Resolution:_ Wait, or move on. It shouldn't take more than a few minutes, and certainly not more than fifteen.
+
+## 7. Dealing with State
+
+### Common Issues
+
+#### Students misunderstand parameters
+
+Students sometimes don't understand the name parameter.
+
+_Resolution:_ Make sure to explain that they can name the service instance whatever they like, for example "_You might store user data in it, and call it `users`._"
+
+#### Provisioning on Swisscom times out
+
+Sometimes service provisioning has been observed to time out after 10 minutes. The operation cannot be cancelled.
+
+_Resolution:_ Contact Swisscom if this issue is seen, and the only option is to wait.

--- a/basics/site/README.md
+++ b/basics/site/README.md
@@ -79,3 +79,19 @@ _Resolution:_ Ensure the student has the latest CF CLI release.
 Users may run `cf logs` which tails, and either think it hasn't worked because an app isn't logging, or may not know how to exit.
 
 _Resolution:_ CTRL+C
+
+## 4. Buildpacks
+
+### Common Issues
+
+#### `cf ssh` appearing to hang on Windows
+
+Some terminal emulators on Windows particularly (including Git Bash's bundled emu) don't display a prompt when `cf ssh` has successfully connected, making it _look_ like the command is hanging.
+
+_Resolution:_ None needed.
+
+#### Students don't understand how to explore the running container
+
+Novice command-line users may need some help navigating the filesystem, and an explanation of what the files present _mean_.
+
+_Resolution:_ Draw common filesystem navigation commands on the whiteboard; discuss file differences in the recap.

--- a/basics/site/config.toml
+++ b/basics/site/config.toml
@@ -17,7 +17,7 @@ googleAnalytics = "UA-67001027-2"
 	provider = "GitHub"
 	repo_url = "https://github.com/cloudfoundry/summit-training-classes"
 
-	version = "1.4.0"
+	version = "1.5.0"
   headerLogo = "/img/cf-white.png"
   logo = "img/cf-rabbit.png"
 	favicon = ""

--- a/basics/site/content/labs/availability.md
+++ b/basics/site/content/labs/availability.md
@@ -48,6 +48,6 @@ $ cf app imperfect-app
 
   * Read the [Twelve-Factor App](http://12factor.net/)
   * Benchmark app with [Load Impact](https://loadimpact.com/) (crash 1-2 instances)
-  * Read about [Blue-Green deployment in CF](http://garage.mybluemix.net/posts/blue-green-deployment/)
+  * Read about [Zero-downtime deployments in CF](http://garage.mybluemix.net/posts/blue-green-deployment/)
   * Use [cf-blue-green-deploy](https://github.com/bluemixgaragelondon/cf-blue-green-deploy) CLI plugin
   * [Coding Horror wisdom](http://blog.codinghorror.com/version-1-sucks-but-ship-it-anyway/)

--- a/basics/site/content/labs/buildpacks.md
+++ b/basics/site/content/labs/buildpacks.md
@@ -61,7 +61,7 @@ called `Staticfile`.
 
 Instead of letting Cloud Foundry allow each buildpack to detect whether it can run the app, we're going to specify which buildpack we want to use.
 
-{{% do %}}Push the app again, using a flag to specify this buildpack: `https://github.com/cloudfoundry/staticfile-buildpack` (use `cf push --help` to find out which flag to provide){{% /do %}}
+{{% do %}}Push the app again, using a flag to specify this buildpack: `https://github.com/cloudfoundry/staticfile-buildpack` (use `cf push -\-help` to find out which flag to provide){{% /do %}}
 {{% observe %}}Observe from the CLI output which buildpack was used{{% /observe %}}
 {{% do %}}Hit both `/index.html` and `/index.php`{{% /do %}}
 {{% question %}}What happens this time? Why?{{% /question %}}

--- a/basics/site/content/labs/cli.md
+++ b/basics/site/content/labs/cli.md
@@ -64,6 +64,6 @@ $ cf target -o ORG -s SPACE
 ## Beyond the Class
 
   * Add the person next to you to your Cloud Foundry space
-  * Create an account on [IBM Bluemix](https://console.ng.bluemix.net/registration/)
-  * Use [Targets CF CLI plugin](https://github.com/guidowb/cf-targets-plugin) with PWS &amp; Bluemix
+  * Create an account on [IBM Cloud](https://console.ng.bluemix.net/registration/)
+  * Use [Targets CF CLI plugin](https://github.com/guidowb/cf-targets-plugin)
   * Submit a localisation pull request to [CF CLI](https://github.com/cloudfoundry/cli/blob/master/cf/i18n/README-i18n.md)

--- a/basics/site/content/labs/debugging.md
+++ b/basics/site/content/labs/debugging.md
@@ -20,7 +20,7 @@ A buggy app is included in the `06-debugging/debug-app` directory with a manifes
 
 Getting fast feedback on failures is a key element of agility. The sooner we know something is broken, the sooner we can fix it.
 
-{{% do %}}Use `cf push --help` and Cloud Foundry documentation to push the app again, in a way that Cloud Foundry will deem it unhealthy{{% /do %}}
+{{% do %}}Use `cf push -\-help` and Cloud Foundry documentation to push the app again, in a way that Cloud Foundry will deem it unhealthy{{% /do %}}
 
 ## Check out the Logs
 

--- a/basics/site/content/labs/new-account.md
+++ b/basics/site/content/labs/new-account.md
@@ -29,6 +29,6 @@ You must have an account to continue.
 Compare CF public services:
 
   * [Anynines](http://www.anynines.com/)
-  * [IBM Bluemix](https://console.ng.bluemix.net/)
+  * [IBM Cloud](https://www.ibm.com/cloud/)
   * [Pivotal Web Services](https://run.pivotal.io/)
   * [Swisscom](https://developer.swisscom.com/)

--- a/basics/site/content/labs/routes.md
+++ b/basics/site/content/labs/routes.md
@@ -17,7 +17,7 @@ At some point we will want to push an updated v1.1 of our app, find out if it wo
 
 We need to create a route for the app we are going to deploy. This route will be used for _all_ versions of the app, so should stay the same even when the app is updated.
 
-{{% do %}}Use `cf create-route` to a create a new route for your app, making sure the domain is `cfapps.io` if you are using Pivotal Web Services, or `scapp.io` if you are using The Swisscom Application Cloud{{% /do %}}
+{{% do %}}Use `cf create-route` to a create a new route for your app, making sure the address is `www-yourname.cfapps.io` if you are using Pivotal Web Services, or `www-yourname.scapp.io` if you are using The Swisscom Application Cloud{{% /do %}}
 
 ### Push v1.0
 

--- a/basics/site/content/labs/state.md
+++ b/basics/site/content/labs/state.md
@@ -28,7 +28,7 @@ redis   rediscloud   30mb                create succeeded
 
 You need to bind your service instance to your application so it can be used.
 
-{{% do %}}Push `07-shared-state/stateful-app` with the `--no-start` flag{{% /do %}}
+{{% do %}}Push `07-shared-state/stateful-app` with the `-\-no-start` flag{{% /do %}}
 {{% do %}}Use `cf bind-service` to bind your service instance to your app{{% /do %}}
 {{% question %}}Does this work immediately? If not, why not? What commands can you use to find out more?{{% /question %}}
 {{% do %}}Start your app so that it can pick up the environment variables{{% /do %}}

--- a/basics/slides/README.md
+++ b/basics/slides/README.md
@@ -2,4 +2,23 @@
 
 This document provides notes for would-be instructors of the Zero To Hero course. Please endeavour to keep this up-to-date when making changes to the slides themselves.
 
+## 1. What is Cloud Foundry?
 
+Students must understand the importance of Cloud Foundry in the wider context of the industry and of digital transformation.
+
+Establish early that this course focuses on the _Application Runtime_ and not the _Container Runtime_.
+
+### Key Takeaways
+
+* Cloud Foundry enables you to **deliver software more quickly**, which in turn allows an organisation to become a continuously-delivering _learning_ organisation. The **step-change in pace is transformative**.
+* Cloud Foundry allows freedom and flexibility. It is **portable across IaaSes**, allows the use of **any language** (which may be novel in large enterprises), and the consumption of any data service.
+* Cloud Foundry is **primarily suited towards 12 Factor apps**, but can also run monoliths (via Docker-based apps, volume services). It doesn't mean you _should_, though.
+* The CFF owns the IP, meaning **the project can't be subverted by one vendor**.
+
+### Notes
+
+This section often takes the longest, as there's a lot of background that can be explained.
+
+You may need to explain what the 12 Factor manifesto is.
+
+For a non-operator audience, the "where to get OS CF" slide is of minimal important. If you've got operators, they'll be keen to expand on this a little.

--- a/basics/slides/README.md
+++ b/basics/slides/README.md
@@ -42,3 +42,24 @@ Orgs can separate tenants - if the students are using a public CF like PWS, then
 Spaces are often used like environments, eg "dev", "staging", "UAT".
 
 Quotas are primarily an operator concern, and often at most a curiosity for developers.
+
+## 3. Pushing Your First App
+
+Expose the inner working of `cf push` to enable students to develop an accurate mental model of the system and reason about any issues they may face.
+
+### Key Takeaways
+
+* **Cloud Foundry adds whatever your app needs** to make it runnable.
+* Buildpacks allow flexibility, and can be thought of as a little like "plug-ins".
+* Cloud Foundry **keeps a copy of your app code**.
+* App instances run on Diego Cells.
+
+### Notes
+
+Students will have endured two fairly tedious and uninteresting labs to get to this point, so everything may be seeming a little abstract. At this point, energise the students by emphasising that this is where the exciting stuff starts.
+
+The sequence diagram may seem quite dull, but is important for starting to expose the inner workings of Cloud Foundry, which will be revisited again in the post-lab recap sessions.
+
+Some non-technical students may be confused what an "app instance" is. It may be necessary to delve into what a VM is when talking about Diego Cells, and also to explain containerisation at some level (ranging from "_apps can't see each other_" to a full explanation).
+
+That staging containers are destroyed has security benefits - build tooling is not present in running droplets.

--- a/basics/slides/README.md
+++ b/basics/slides/README.md
@@ -123,3 +123,23 @@ Many users do not realise that `cf logs` does not store their logs indefinitely,
 Recommend to students that if log entries need to be kept for regulatory purposes, they should be stored in a transactional data store instead.
 
 `cf ssh` is a particularly dangerous command as it can change the state of running applications, completely invalidating testing and governance. Students should be discouraged from using it except when issues cannot be replicated anywhere other than the live environment.
+
+## 7. Dealing with State
+
+Demonstrate the power and flexibility of the service broker model, and ensure students understand the lifecycle of service instances.
+
+### Key Takeaways
+
+* Storing state outside of apps is essential to allow **horizontal scalability**
+* Service brokers are like 'plug ins' that allow CF users to provision databases and other services
+* Service credentials are provided through environment variables
+
+### Notes
+
+The lab for this module is quite long.
+
+Some students may not be familiar with the term "sticky sessions", and may need some exposition on that pattern. Breaking out to a whiteboard to explain how sticky sessions and app server clustering worked in the past may be helpful. Referencing Zynga's Farmville and the 'shared nothing' architecture where all state was in the database may help to illustrate that pushing the complex logic of data replication to a data service is probably better than doing it in app code.
+
+Explaining service instances in the abstract can be difficult, as a service _could_ be anything, and it could end up running anywhere.
+
+Often students ask how _they_ can connect to service instances, in which case a verbal explanation of service keys may be useful, along with pointing out that one might not have network connectivity between a workstation and the service instance.

--- a/basics/slides/README.md
+++ b/basics/slides/README.md
@@ -31,7 +31,7 @@ In addition to enumerating the ways that students can interact with Cloud Foundr
 
 * The **CLI is universal** and will work on any certified Cloud Foundry.
 * **Web UIs are mostly proprietary**, and therefore the course does not teach them.
-* Apps live in spaces, and **you can't have two apps with the same name in the space space**.
+* Apps live in spaces, and **you can't have two apps with the same name in the same space**.
 
 ### Notes
 

--- a/basics/slides/README.md
+++ b/basics/slides/README.md
@@ -81,3 +81,25 @@ Explain the rationale for buildpacks and the benefits they bring.
 Students often benefit from examples of what "dependencies" really means in this context, so providing an explanation in relation to languages they're familiar with will help. Perhaps clarify to Java developers that the Java Buildpack does not compile their code or pull down Maven dependencies. By contrast, the Golang buildpack _does_ compile source code!
 
 This module is a good opportunity to highlight the differences between pushing apps and using buildpacks, versus pushing Docker images. The latter can't be restaged and are opaque to the operator - the people running the platform have no idea of what has been pushed. Buildpacks also save a lot of effort in CI pipelines in comparison to building and pushing Docker images.
+
+## 5. Resilience and Availability
+
+Explain the paradox of why cloud environments make failure more likely, but allow for greater resilience.
+
+### Key Takeaways
+
+* **CF is self-healing** and will restart unhealthy apps without paging a human
+* When deployed with **BOSH**, there are **additional levels of recoverability**
+* **Running more instances of an app results in greater availability**, but apps must be written to allow multiple instances to be run.
+
+### Notes
+
+This is a key moment to remind students that they won't get all the benefits of the cloud that sales people promised them, unless they change their habits.
+
+Explaining why embracing failure leads to increased availability can be somewhat of a tangent. Having more instances means that failure is not absolute, giving us the opportunity to learn from it and adapt. This is in stark contrast to the 'robust' approach of traditional enterprise IT of having one sacred server that is protected at all costs, but when it fails, it fails catastrophically. A sidetrack into the topic of antifragility here is entirely possible.
+
+Talking about BOSH may be appropriate here, explaining how it will restart processes (ie Diego itself), restart missing VMs, and allow VMs to be striped across availability zones. However, it is best to avoid the inaccurate phrase "Four Levels of HA" that was used in the past, as these features make the system very recoverable, but not highly available - you will have downtime, but the system will right itself.
+
+Students may benefit from being reminded that their apps may need to change. For example, leader election or external scheduling may be required when migrating from a monolith to many replicas of an app.
+
+The slide on health management components is often superfluous.

--- a/basics/slides/README.md
+++ b/basics/slides/README.md
@@ -1,0 +1,5 @@
+# Instructor Notes
+
+This document provides notes for would-be instructors of the Zero To Hero course. Please endeavour to keep this up-to-date when making changes to the slides themselves.
+
+

--- a/basics/slides/README.md
+++ b/basics/slides/README.md
@@ -63,3 +63,21 @@ The sequence diagram may seem quite dull, but is important for starting to expos
 Some non-technical students may be confused what an "app instance" is. It may be necessary to delve into what a VM is when talking about Diego Cells, and also to explain containerisation at some level (ranging from "_apps can't see each other_" to a full explanation).
 
 That staging containers are destroyed has security benefits - build tooling is not present in running droplets.
+
+## 4. Buildpacks
+
+Explain the rationale for buildpacks and the benefits they bring.
+
+### Key Takeaways
+
+* Buildpacks save developers from having to know or care how their apps become runnable - **they provide a separation of concerns**.
+* **Buildpacks allow operators control** over what middleware and languages are available on their platform.
+* Because CF keeps app code and droplets separately, **_operators_ can restage an app** to update its dependencies (and therefore patch security issues), without needing the app team's involvement.
+* Buildpacks are _just scripts_.
+* Restriction of buildpacks and their capabilities is often important in regulated environments.
+
+### Notes
+
+Students often benefit from examples of what "dependencies" really means in this context, so providing an explanation in relation to languages they're familiar with will help. Perhaps clarify to Java developers that the Java Buildpack does not compile their code or pull down Maven dependencies. By contrast, the Golang buildpack _does_ compile source code!
+
+This module is a good opportunity to highlight the differences between pushing apps and using buildpacks, versus pushing Docker images. The latter can't be restaged and are opaque to the operator - the people running the platform have no idea of what has been pushed. Buildpacks also save a lot of effort in CI pipelines in comparison to building and pushing Docker images.

--- a/basics/slides/README.md
+++ b/basics/slides/README.md
@@ -103,3 +103,23 @@ Talking about BOSH may be appropriate here, explaining how it will restart proce
 Students may benefit from being reminded that their apps may need to change. For example, leader election or external scheduling may be required when migrating from a monolith to many replicas of an app.
 
 The slide on health management components is often superfluous.
+
+## 6. Debugging
+
+Give students the tools they need to debug broken apps of their own after finishing the course.
+
+### Key Takeaways
+
+* `cf logs` tells you what the app thinks is happening.
+* `cf events` tells you what the _platform_ thinks is happening.
+* **Logs in Cloud Foundry are not kept indefinitely**.
+* Logs in Cloud Foundry are 'best effort' and **may be lost**.
+* Use of **`cf ssh` should be discouraged**.
+
+### Notes
+
+Many users do not realise that `cf logs` does not store their logs indefinitely, and also do not realise that log entries may be lost altogether. Some students may perceive this latter point as a weakness of the platform, so explaining the extreme performance impact of guaranteed log delivery in a distributed environment may be required.
+
+Recommend to students that if log entries need to be kept for regulatory purposes, they should be stored in a transactional data store instead.
+
+`cf ssh` is a particularly dangerous command as it can change the state of running applications, completely invalidating testing and governance. Students should be discouraged from using it except when issues cannot be replicated anywhere other than the live environment.

--- a/basics/slides/README.md
+++ b/basics/slides/README.md
@@ -143,3 +143,21 @@ Some students may not be familiar with the term "sticky sessions", and may need 
 Explaining service instances in the abstract can be difficult, as a service _could_ be anything, and it could end up running anywhere.
 
 Often students ask how _they_ can connect to service instances, in which case a verbal explanation of service keys may be useful, along with pointing out that one might not have network connectivity between a workstation and the service instance.
+
+## 8. Domains and Routes
+
+Students should be able to exploit route mapping for the purpose of zero-downtime deployments.
+
+### Key Takeaways
+
+* Routes and apps have separate lifecycles
+* **Route mapping can allow zero-downtime deployments** of apps
+* Custom domains can be registered so that, with some DNS configuration, `www.your-domain.com` can point to a public Cloud Foundry, or a Cloud Foundry of your own
+
+### Notes
+
+Avoid the term "blue/green". This term refers to entire environments, full of collaborating apps, being stood up and switched between. This is not what we do in the cloud native world - we want to be able to perform a zero-downtime deployment of apps within a collaborating ecosystem of microservices, not change the whole lot at once.
+
+The mechanism of zero-downtime deploys often confuses students. Breaking out to a white board to draw a diagram of a 'front door' route (`www.myshop.com`) being mapped to different versions of an app may help.
+
+Often students find that it seems nonsensical to have one route mapped to two apps. Pointing out that Cloud Foundry doesn't know that two different apps could be different versions of the same codebase tends to alleviate this - ie, the route isn't mapped to completely different apps, but v1 and v2 of the same app.

--- a/basics/slides/README.md
+++ b/basics/slides/README.md
@@ -22,3 +22,23 @@ This section often takes the longest, as there's a lot of background that can be
 You may need to explain what the 12 Factor manifesto is.
 
 For a non-operator audience, the "where to get OS CF" slide is of minimal important. If you've got operators, they'll be keen to expand on this a little.
+
+## 2. Interacting with Cloud Foundry
+
+In addition to enumerating the ways that students can interact with Cloud Foundry, establish a mental model of orgs and spaces before they start pushing apps.
+
+### Key Takeaways
+
+* The **CLI is universal** and will work on any certified Cloud Foundry.
+* **Web UIs are mostly proprietary**, and therefore the course does not teach them.
+* Apps live in spaces, and **you can't have two apps with the same name in the space space**.
+
+### Notes
+
+Orgs and spaces are usually just logical divisions; however with Isolation Segments, orgs can be tied to particular subsets of underlying infrastructure.
+
+Orgs can separate tenants - if the students are using a public CF like PWS, then they will each have their own org in one big Cloud Foundry. In large enterprises, an org might map to a business unit or a 'big A' application (set of apps).
+
+Spaces are often used like environments, eg "dev", "staging", "UAT".
+
+Quotas are primarily an operator concern, and often at most a curiosity for developers.

--- a/basics/slides/data/sections/01-what-is-cf-01-goal.yml
+++ b/basics/slides/data/sections/01-what-is-cf-01-goal.yml
@@ -4,5 +4,4 @@ type: "statement"
 backgroundColor: "#243641"
 buildInStatements: "true"
 statements:
-  - I want a *CF account*
-  - So that I can use *Cloud&nbsp;Foundry*
+  - How can I access *Cloud&nbsp;Foundry?*

--- a/basics/slides/data/sections/02-interacting-01-goal.yml
+++ b/basics/slides/data/sections/02-interacting-01-goal.yml
@@ -4,5 +4,4 @@ type: "statement"
 backgroundColor: "#243641"
 buildInStatements: false
 statements:
-  - I want to have a *command line* utility installed
-  - So that I can *deploy apps* into my CF account
+  - How can I interact with *Cloud&nbsp;Foundry?*

--- a/basics/slides/data/sections/03-pushing-01-goal.yml
+++ b/basics/slides/data/sections/03-pushing-01-goal.yml
@@ -4,5 +4,4 @@ type: "statement"
 backgroundColor: "#243641"
 buildInStatements: false
 statements:
-  - I want my app to be *accessible at a public URL*
-  - So that the *whole world* can see it
+  - How can I access my *running app?*

--- a/basics/slides/data/sections/03-pushing-01-goal.yml
+++ b/basics/slides/data/sections/03-pushing-01-goal.yml
@@ -4,4 +4,4 @@ type: "statement"
 backgroundColor: "#243641"
 buildInStatements: false
 statements:
-  - How can I access my *running app?*
+  - How can I run my code in *Cloud&nbsp;Foundry?*

--- a/basics/slides/data/sections/04-buildpacks-01-goal.yml
+++ b/basics/slides/data/sections/04-buildpacks-01-goal.yml
@@ -4,4 +4,4 @@ type: "statement"
 backgroundColor: "#243641"
 buildInStatements: false
 statements:
-  - How can I leverage *Cloud&nbsp;Foundry* to manage *my dependencies?*
+  - What does *Cloud&nbsp;Foundry* do to my code to make my app runnable?

--- a/basics/slides/data/sections/04-buildpacks-01-goal.yml
+++ b/basics/slides/data/sections/04-buildpacks-01-goal.yml
@@ -4,5 +4,4 @@ type: "statement"
 backgroundColor: "#243641"
 buildInStatements: false
 statements:
-  - I want the PaaS to *manage dependencies*
-  - So that I can *focus on my application code*
+  - How can I leverage *Cloud&nbsp;Foundry* to manage *my dependencies?*

--- a/basics/slides/data/sections/04-buildpacks-14-how.yml
+++ b/basics/slides/data/sections/04-buildpacks-14-how.yml
@@ -20,18 +20,32 @@ columnLeftContent: |
 columnRightContent: |
 
   * `bin/detect`: Can I handle this? (introspection)
-  * `bin/compile`: If yes, make the droplet
+  * `bin/supply`: If yes, provide the dependencies
+  * `bin/finalize`: Prepare the app for launch - runs only for the last buildpack
   * `bin/release`: Build the metadata (env variables, start command, etc)
 
 notes: |
 
-  run in containers
+  `bin/compile`: is a deprecated alternative to `bin/supply` and `bin/finalize`
 
-  ---
+  Buildpack execution and app runtime are in containers
 
-  ## [Where does the](#/6) buildpack [run?](#/6)
+  * Uses the host kernel with a rootfs (jeos)
+  * Default rootfs is <span style="color: #8FF541;">cflinuxfs2</span> (based on Ubuntu 14.04 Trusty)
+  * Moving towards <span style="color: #0008FF;">cflinuxfs3</span> (based on Ubuntu 18.04 Bionic)
+  * Cloud Foundry uses [Garden](https://github.com/cloudfoundry-incubator/garden) for containerisation
 
-    * Uses the host kernel with a rootfs (jeos)
-    * Default rootfs is <span style="color: #8FF541;">cflinuxfs2</span> (based on Ubuntu 14.04 Trusty)
-    * Buildpack execution and app runtime are in containers
-    * Cloud Foundry uses [Garden](https://github.com/cloudfoundry-incubator/garden) for containerisation
+  Script examples from staticfile buildpack:
+
+  * `detect`: is there a Staticfile?
+  * `supply`: install nginx
+  * `finalize`: look at provided config, configure nginx, then creates `boot.sh`
+  * `release`: creates yaml file:
+
+    ```yaml
+    ---
+    default_process_types:
+    web: \$HOME/boot.sh
+    ```
+
+  More info: https://docs.cloudfoundry.org/buildpacks/understand-buildpacks.html

--- a/basics/slides/data/sections/05-availability-01-goal.yml
+++ b/basics/slides/data/sections/05-availability-01-goal.yml
@@ -4,5 +4,4 @@ type: "statement"
 backgroundColor: "#243641"
 buildInStatements: false
 statements:
-  - I want my app to be *resilient*
-  - So that random failures *won't* take it offline
+  - How can I make my app *resilient?*

--- a/basics/slides/data/sections/06-debugging-01-goal.yml
+++ b/basics/slides/data/sections/06-debugging-01-goal.yml
@@ -4,4 +4,4 @@ type: "statement"
 backgroundColor: "#243641"
 buildInColumns: "false"
 statements:
-  - How can I *debug* my app?
+  - How can I *investigate problems* with my app?

--- a/basics/slides/data/sections/06-debugging-01-goal.yml
+++ b/basics/slides/data/sections/06-debugging-01-goal.yml
@@ -4,5 +4,4 @@ type: "statement"
 backgroundColor: "#243641"
 buildInColumns: "false"
 statements:
-  - I want to know what my CF *app is doing*
-  - So that *I can debug* it
+  - How can I *debug* my app?

--- a/basics/slides/data/sections/07-state-01-goal.yml
+++ b/basics/slides/data/sections/07-state-01-goal.yml
@@ -4,4 +4,4 @@ type: "statement"
 backgroundColor: "#243641"
 buildInColumns: "false"
 statements:
-  - How can I *persist* app data?
+  - How can I *share persistent data* between app instances?

--- a/basics/slides/data/sections/07-state-01-goal.yml
+++ b/basics/slides/data/sections/07-state-01-goal.yml
@@ -4,5 +4,4 @@ type: "statement"
 backgroundColor: "#243641"
 buildInColumns: "false"
 statements:
-  - I want to store *data in a service*
-  - So that it is *persistent* and shared
+  - How can I *persist* app data?

--- a/basics/slides/data/sections/08-routes-01-goal.yml
+++ b/basics/slides/data/sections/08-routes-01-goal.yml
@@ -4,5 +4,4 @@ type: "statement"
 backgroundColor: "#243641"
 buildInColumns: "false"
 statements:
-  - I want to deploy a *new version* of my app
-  - With *no interruptions* to my users
+  - How can I deploy with *zero downtime?*

--- a/basics/slides/data/sections/08-routes-02-agenda.yml
+++ b/basics/slides/data/sections/08-routes-02-agenda.yml
@@ -13,4 +13,4 @@ columnRightContent: |
 
     * Custom Domains
     * Routes
-    * Blue/Green Deployments
+    * Zero-downtime Deployments

--- a/basics/slides/data/sections/08-routes-14-blue-green.yml
+++ b/basics/slides/data/sections/08-routes-14-blue-green.yml
@@ -1,17 +1,17 @@
 type: "two-column"
-menuTitle: "Blue Green Deployments"
+menuTitle: "Zero-downtime Deployments"
 buildInColumns: "false"
 
-columnLeftTitle: "Blue/Green Deployments"
+columnLeftTitle: "Zero-downtime Deployments"
 
 columnLeftContent: |
 
 columnRightContent: |
 
-  * Deploy a new version (GREEN) of your app.
+  * Deploy a new version of your app.
   * Map the route to it
   * Validate
-  * Unmap from the old version (BLUE)
+  * Unmap from the old version
 
 notes: |
 

--- a/basics/slides/themes/hugo-theme-pivotal-revealjs/layouts/index.html
+++ b/basics/slides/themes/hugo-theme-pivotal-revealjs/layouts/index.html
@@ -1,141 +1,133 @@
 <!DOCTYPE html>
 <html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}">
-    <head>
-        {{ partial "head.html" . }}
-    </head>
-    <body>
-      <div class="reveal">
-        <div class="slides">
-          {{ partial "title-slide.html" . }}
 
-          {{ range $.Site.Data.sections }}
-            {{ partial "content-slide.html" . }}
-          {{ end }}
+<head>
+  {{ partial "head.html" . }}
+</head>
 
-          {{ partial "last-slide.html" . }}
-        </div>
-        <div class="copyright">
-          {{ if isset $.Site.Params "copyright" }}
-        	  {{ $.Site.Params.copyright }}
-          {{ else }}
-            (C) Copyright 2016 Cloud Foundry Foundation, Inc. All Rights Reserved.
-          {{ end }}
-        </div>
-  			<div class="logo">
-          {{ if isset $.Site.Params "logo" }}
-  				  <img src="{{ $.Site.Params.logo }}" alt="logo" title="logo" />
-          {{ else }}
-            <img src="img/Pivotal_Teal.png" alt="Pivotal logo" title="Pivotal" />
-          {{ end }}
-  			</div>
-      </div>
+<body>
+  <div class="reveal">
+    <div class="slides">
+      {{ partial "title-slide.html" . }} {{ range $.Site.Data.sections }} {{ partial "content-slide.html" . }} {{ end }} {{ partial
+      "last-slide.html" . }}
+    </div>
+    <div class="copyright">
+      {{ if isset $.Site.Params "copyright" }} {{ $.Site.Params.copyright }} {{ else }} (C) Copyright 2016-Present Cloud Foundry
+      Foundation, Inc. All Rights Reserved. {{ end }}
+    </div>
+    <div class="logo">
+      {{ if isset $.Site.Params "logo" }}
+      <img src="{{ $.Site.Params.logo }}" alt="logo" title="logo" /> {{ else }}
+      <img src="img/Pivotal_Teal.png" alt="Pivotal logo" title="Pivotal" /> {{ end }}
+    </div>
+  </div>
 
 
-      {{ partial "js.html" . }}
-      {{ partial "settings.html" . }}
-      <script>
+  {{ partial "js.html" . }} {{ partial "settings.html" . }}
+  <script>
 
-        Reveal.initialize({
-          controls: true,
-          progress: true,
-          slideNumber: true,
-          history: true,
-          keyboard: true,
-          overview: true,
-          center: false,
-          touch: true,
-          loop: false,
-          rtl: false,
-          fragments: true,
-          embedded: false,
-          help: true,
-          showNotes: false,
-          previewLinks: true,
-          transition: 'slide', // none/fade/slide/convex/concave/zoom
-          backgroundTransition: 'fade',
-          margin: 0,
-          minScale: 0.2,
-          maxScale: 2.0,
+    Reveal.initialize({
+      controls: true,
+      progress: true,
+      slideNumber: true,
+      history: true,
+      keyboard: true,
+      overview: true,
+      center: false,
+      touch: true,
+      loop: false,
+      rtl: false,
+      fragments: true,
+      embedded: false,
+      help: true,
+      showNotes: false,
+      previewLinks: true,
+      transition: 'slide', // none/fade/slide/convex/concave/zoom
+      backgroundTransition: 'fade',
+      margin: 0,
+      minScale: 0.2,
+      maxScale: 2.0,
 
-          /* Reveal.configure({ autoSlide: 0 }); configure while running.  use this for turning on/off notes */
+      /* Reveal.configure({ autoSlide: 0 }); configure while running.  use this for turning on/off notes */
 
-          dependencies: [
-              // Cross-browser shim that fully implements classList - https://github.com/eligrey/classList.js/
-            { src: 'lib/js/classList.js', condition: function() { return !document.body.classList; } },
+      dependencies: [
+        // Cross-browser shim that fully implements classList - https://github.com/eligrey/classList.js/
+        { src: 'lib/js/classList.js', condition: function () { return !document.body.classList; } },
 
-            // Interpret Markdown in <section> elements
-            { src: 'plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
-            { src: 'plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
+        // Interpret Markdown in <section> elements
+        { src: 'plugin/markdown/marked.js', condition: function () { return !!document.querySelector('[data-markdown]'); } },
+        { src: 'plugin/markdown/markdown.js', condition: function () { return !!document.querySelector('[data-markdown]'); } },
 
-            // Syntax highlight for <code> elements
-            { src: 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
+        // Syntax highlight for <code> elements
+        { src: 'plugin/highlight/highlight.js', async: true, callback: function () { hljs.initHighlightingOnLoad(); } },
 
-            // Zoom in and out with Alt+click
-            { src: 'plugin/zoom-js/zoom.js', async: true },
+        // Zoom in and out with Alt+click
+        { src: 'plugin/zoom-js/zoom.js', async: true },
 
-            // Speaker notes
-            { src: 'plugin/notes/notes.js', async: true },
+        // Speaker notes
+        { src: 'plugin/notes/notes.js', async: true },
 
-            // MathJax
-            { src: 'plugin/math/math.js', async: true },
+        // MathJax
+        { src: 'plugin/math/math.js', async: true },
 
-            { src: 'plugin/menu/menu.js', async: true }
-					],
+        { src: 'plugin/menu/menu.js', async: true }
+      ],
 
-          menu: {
-            // Specifies which side of the presentation the menu will
-            // be shown. Use 'left' or 'right'.
-            side: 'left',
+      menu: {
+        // Specifies which side of the presentation the menu will
+        // be shown. Use 'left' or 'right'.
+        side: 'left',
 
-            // Add slide numbers to the titles in the slide list.
-            // Use 'true' or format string (same as reveal.js slide numbers)
-            numbers: false,
+        // Add slide numbers to the titles in the slide list.
+        // Use 'true' or format string (same as reveal.js slide numbers)
+        numbers: false,
 
-            // Hide slides from the menu that do not have a title.
-            // Set to 'true' to only list slides with titles.
-            hideMissingTitles: false,
+        // Hide slides from the menu that do not have a title.
+        // Set to 'true' to only list slides with titles.
+        hideMissingTitles: false,
 
-            // Add markers to the slide titles to indicate the
-            // progress through the presentation
-            markers: true,
+        // Add markers to the slide titles to indicate the
+        // progress through the presentation
+        markers: true,
 
-            // Specify custom panels to be included in the menu, by
-            // providing an array of objects with 'title', 'icon'
-            // properties, and either a 'src' or 'content' property.
+        // Specify custom panels to be included in the menu, by
+        // providing an array of objects with 'title', 'icon'
+        // properties, and either a 'src' or 'content' property.
 
 
-            // Specifies the themes that will be available in the themes
-            // menu panel. Set to 'false' to hide themes panel.
-            themes: false,
+        // Specifies the themes that will be available in the themes
+        // menu panel. Set to 'false' to hide themes panel.
+        themes: false,
 
-            // Specifies if the transitions menu panel will be shown.
-            transitions: false,
+        // Specifies if the transitions menu panel will be shown.
+        transitions: false,
 
-            // Adds a menu button to the slides to open the menu panel.
-            // Set to 'false' to hide the button.
-            openButton: true,
+        // Adds a menu button to the slides to open the menu panel.
+        // Set to 'false' to hide the button.
+        openButton: true,
 
-            // If 'true' allows the slide number in the presentation to
-            // open the menu panel. The reveal.js slideNumber option must
-            // be displayed for this to take effect
-            openSlideNumber: false,
+        // If 'true' allows the slide number in the presentation to
+        // open the menu panel. The reveal.js slideNumber option must
+        // be displayed for this to take effect
+        openSlideNumber: false,
 
-            // If true allows the user to open and navigate the menu using
-            // the keyboard. Standard keyboard interaction with reveal
-            // will be disabled while the menu is open.
-            keyboard: true
-          }
-/*
-				    keyboard: {
-				        82: function() { Recorder.toggleRecording(); }, // press 'r' to start/stop recording
-				        90: function() { Recorder.downloadZip(); }  // press 'z' to download zip containing audio files
-				    }*/
-        });
+        // If true allows the user to open and navigate the menu using
+        // the keyboard. Standard keyboard interaction with reveal
+        // will be disabled while the menu is open.
+        keyboard: true
+      }
+      /*
+                  keyboard: {
+                      82: function() { Recorder.toggleRecording(); }, // press 'r' to start/stop recording
+                      90: function() { Recorder.downloadZip(); }  // press 'z' to download zip containing audio files
+                  }*/
+    });
 
-        Reveal.addEventListener( 'ready', function( event ) {
-          PresentationSettings.updateFromCookie();
-        });
+    Reveal.addEventListener('ready', function (event) {
+      PresentationSettings.updateFromCookie();
+    });
 
-      </script>
-    </body>
+  </script>
+</body>
+
 </html>

--- a/basics/slides/themes/hugo-theme-pivotal-revealjs/layouts/index.html
+++ b/basics/slides/themes/hugo-theme-pivotal-revealjs/layouts/index.html
@@ -1,133 +1,141 @@
 <!DOCTYPE html>
 <html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}">
+    <head>
+        {{ partial "head.html" . }}
+    </head>
+    <body>
+      <div class="reveal">
+        <div class="slides">
+          {{ partial "title-slide.html" . }}
 
-<head>
-  {{ partial "head.html" . }}
-</head>
+          {{ range $.Site.Data.sections }}
+            {{ partial "content-slide.html" . }}
+          {{ end }}
 
-<body>
-  <div class="reveal">
-    <div class="slides">
-      {{ partial "title-slide.html" . }} {{ range $.Site.Data.sections }} {{ partial "content-slide.html" . }} {{ end }} {{ partial
-      "last-slide.html" . }}
-    </div>
-    <div class="copyright">
-      {{ if isset $.Site.Params "copyright" }} {{ $.Site.Params.copyright }} {{ else }} (C) Copyright 2016-Present Cloud Foundry
-      Foundation, Inc. All Rights Reserved. {{ end }}
-    </div>
-    <div class="logo">
-      {{ if isset $.Site.Params "logo" }}
-      <img src="{{ $.Site.Params.logo }}" alt="logo" title="logo" /> {{ else }}
-      <img src="img/Pivotal_Teal.png" alt="Pivotal logo" title="Pivotal" /> {{ end }}
-    </div>
-  </div>
-
-
-  {{ partial "js.html" . }} {{ partial "settings.html" . }}
-  <script>
-
-    Reveal.initialize({
-      controls: true,
-      progress: true,
-      slideNumber: true,
-      history: true,
-      keyboard: true,
-      overview: true,
-      center: false,
-      touch: true,
-      loop: false,
-      rtl: false,
-      fragments: true,
-      embedded: false,
-      help: true,
-      showNotes: false,
-      previewLinks: true,
-      transition: 'slide', // none/fade/slide/convex/concave/zoom
-      backgroundTransition: 'fade',
-      margin: 0,
-      minScale: 0.2,
-      maxScale: 2.0,
-
-      /* Reveal.configure({ autoSlide: 0 }); configure while running.  use this for turning on/off notes */
-
-      dependencies: [
-        // Cross-browser shim that fully implements classList - https://github.com/eligrey/classList.js/
-        { src: 'lib/js/classList.js', condition: function () { return !document.body.classList; } },
-
-        // Interpret Markdown in <section> elements
-        { src: 'plugin/markdown/marked.js', condition: function () { return !!document.querySelector('[data-markdown]'); } },
-        { src: 'plugin/markdown/markdown.js', condition: function () { return !!document.querySelector('[data-markdown]'); } },
-
-        // Syntax highlight for <code> elements
-        { src: 'plugin/highlight/highlight.js', async: true, callback: function () { hljs.initHighlightingOnLoad(); } },
-
-        // Zoom in and out with Alt+click
-        { src: 'plugin/zoom-js/zoom.js', async: true },
-
-        // Speaker notes
-        { src: 'plugin/notes/notes.js', async: true },
-
-        // MathJax
-        { src: 'plugin/math/math.js', async: true },
-
-        { src: 'plugin/menu/menu.js', async: true }
-      ],
-
-      menu: {
-        // Specifies which side of the presentation the menu will
-        // be shown. Use 'left' or 'right'.
-        side: 'left',
-
-        // Add slide numbers to the titles in the slide list.
-        // Use 'true' or format string (same as reveal.js slide numbers)
-        numbers: false,
-
-        // Hide slides from the menu that do not have a title.
-        // Set to 'true' to only list slides with titles.
-        hideMissingTitles: false,
-
-        // Add markers to the slide titles to indicate the
-        // progress through the presentation
-        markers: true,
-
-        // Specify custom panels to be included in the menu, by
-        // providing an array of objects with 'title', 'icon'
-        // properties, and either a 'src' or 'content' property.
+          {{ partial "last-slide.html" . }}
+        </div>
+        <div class="copyright">
+          {{ if isset $.Site.Params "copyright" }}
+        	  {{ $.Site.Params.copyright }}
+          {{ else }}
+            (C) Copyright 2016 - Present Cloud Foundry Foundation, Inc. All Rights Reserved.
+          {{ end }}
+        </div>
+  			<div class="logo">
+          {{ if isset $.Site.Params "logo" }}
+  				  <img src="{{ $.Site.Params.logo }}" alt="logo" title="logo" />
+          {{ else }}
+            <img src="img/Pivotal_Teal.png" alt="Pivotal logo" title="Pivotal" />
+          {{ end }}
+  			</div>
+      </div>
 
 
-        // Specifies the themes that will be available in the themes
-        // menu panel. Set to 'false' to hide themes panel.
-        themes: false,
+      {{ partial "js.html" . }}
+      {{ partial "settings.html" . }}
+      <script>
 
-        // Specifies if the transitions menu panel will be shown.
-        transitions: false,
+        Reveal.initialize({
+          controls: true,
+          progress: true,
+          slideNumber: true,
+          history: true,
+          keyboard: true,
+          overview: true,
+          center: false,
+          touch: true,
+          loop: false,
+          rtl: false,
+          fragments: true,
+          embedded: false,
+          help: true,
+          showNotes: false,
+          previewLinks: true,
+          transition: 'slide', // none/fade/slide/convex/concave/zoom
+          backgroundTransition: 'fade',
+          margin: 0,
+          minScale: 0.2,
+          maxScale: 2.0,
 
-        // Adds a menu button to the slides to open the menu panel.
-        // Set to 'false' to hide the button.
-        openButton: true,
+          /* Reveal.configure({ autoSlide: 0 }); configure while running.  use this for turning on/off notes */
 
-        // If 'true' allows the slide number in the presentation to
-        // open the menu panel. The reveal.js slideNumber option must
-        // be displayed for this to take effect
-        openSlideNumber: false,
+          dependencies: [
+              // Cross-browser shim that fully implements classList - https://github.com/eligrey/classList.js/
+            { src: 'lib/js/classList.js', condition: function() { return !document.body.classList; } },
 
-        // If true allows the user to open and navigate the menu using
-        // the keyboard. Standard keyboard interaction with reveal
-        // will be disabled while the menu is open.
-        keyboard: true
-      }
-      /*
-                  keyboard: {
-                      82: function() { Recorder.toggleRecording(); }, // press 'r' to start/stop recording
-                      90: function() { Recorder.downloadZip(); }  // press 'z' to download zip containing audio files
-                  }*/
-    });
+            // Interpret Markdown in <section> elements
+            { src: 'plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
+            { src: 'plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
 
-    Reveal.addEventListener('ready', function (event) {
-      PresentationSettings.updateFromCookie();
-    });
+            // Syntax highlight for <code> elements
+            { src: 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
 
-  </script>
-</body>
+            // Zoom in and out with Alt+click
+            { src: 'plugin/zoom-js/zoom.js', async: true },
 
+            // Speaker notes
+            { src: 'plugin/notes/notes.js', async: true },
+
+            // MathJax
+            { src: 'plugin/math/math.js', async: true },
+
+            { src: 'plugin/menu/menu.js', async: true }
+					],
+
+          menu: {
+            // Specifies which side of the presentation the menu will
+            // be shown. Use 'left' or 'right'.
+            side: 'left',
+
+            // Add slide numbers to the titles in the slide list.
+            // Use 'true' or format string (same as reveal.js slide numbers)
+            numbers: false,
+
+            // Hide slides from the menu that do not have a title.
+            // Set to 'true' to only list slides with titles.
+            hideMissingTitles: false,
+
+            // Add markers to the slide titles to indicate the
+            // progress through the presentation
+            markers: true,
+
+            // Specify custom panels to be included in the menu, by
+            // providing an array of objects with 'title', 'icon'
+            // properties, and either a 'src' or 'content' property.
+
+
+            // Specifies the themes that will be available in the themes
+            // menu panel. Set to 'false' to hide themes panel.
+            themes: false,
+
+            // Specifies if the transitions menu panel will be shown.
+            transitions: false,
+
+            // Adds a menu button to the slides to open the menu panel.
+            // Set to 'false' to hide the button.
+            openButton: true,
+
+            // If 'true' allows the slide number in the presentation to
+            // open the menu panel. The reveal.js slideNumber option must
+            // be displayed for this to take effect
+            openSlideNumber: false,
+
+            // If true allows the user to open and navigate the menu using
+            // the keyboard. Standard keyboard interaction with reveal
+            // will be disabled while the menu is open.
+            keyboard: true
+          }
+/*
+				    keyboard: {
+				        82: function() { Recorder.toggleRecording(); }, // press 'r' to start/stop recording
+				        90: function() { Recorder.downloadZip(); }  // press 'z' to download zip containing audio files
+				    }*/
+        });
+
+        Reveal.addEventListener( 'ready', function( event ) {
+          PresentationSettings.updateFromCookie();
+        });
+
+      </script>
+    </body>
 </html>


### PR DESCRIPTION
Added a load of instructor notes
Bluemix is now IBM Cloud
Change buildpack slides now that chained buildpacks are a thing
Copyright notice was wrong, this is fixed
Expanded guidance on route lab
Changed the value statements as they made no sense in the slides; they described what was in the labs
Made CI parameterisable
Favour "zero downtime" over "blue green"
Misc fixes
Version bump