### PR TITLE
Replaced long dash to --

### DIFF
--- a/basics/site/content/labs/state.md
+++ b/basics/site/content/labs/state.md
@@ -28,7 +28,7 @@ redis   rediscloud   30mb                create succeeded
 
 You need to bind your service instance to your application so it can be used.
 
-{{% do %}}Push `07-shared-state/stateful-app` with the `-\-no-start` flag{{% /do %}}
+{{% do %}}Push `07-shared-state/stateful-app` with the `--no-start` flag{{% /do %}}
 {{% do %}}Use `cf bind-service` to bind your service instance to your app{{% /do %}}
 {{% question %}}Does this work immediately? If not, why not? What commands can you use to find out more?{{% /question %}}
 {{% do %}}Start your app so that it can pick up the environment variables{{% /do %}}


### PR DESCRIPTION
The string "Push 07-shared-state/stateful-app with the --no-start flag" looked like this:
![image](https://user-images.githubusercontent.com/2307197/47630103-10c4ce00-db50-11e8-9a57-5c039eefee44.png)

In this PR I've replaced `–` symbol to `--`.