### PR TITLE
Update CAPI v2 docs links to new subdomain

### DIFF
--- a/operator/slides/data/sections/04-cf-monitoring-04-cli.yml
+++ b/operator/slides/data/sections/04-cf-monitoring-04-cli.yml
@@ -18,6 +18,6 @@ notes: |
 
   You can stream an app's logs with `cf logs`, or print recent logs with the `--recent` option.
 
-  `cf events` more narrowly shows you a log of [events](https://apidocs.cloudfoundry.org/263/#events), such as when an app has started or stopped
+  `cf events` more narrowly shows you a log of [events](https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#audit-events), such as when an app has started or stopped
 
   `cf app-nozzle` and `cf nozzle` let you access Cloud Foundry's Firehose on the command line. This streams all logs from all apps and components. You need a CLI plugin for these commands.


### PR DESCRIPTION
This PR updates CAPI v2 docs links from `apidocs.cloudfoundry.org` to `v2-apidocs.cloudfoundry.org`.
The goal is to signal that v3 is the primary API, also a necessary step in eventually sunsetting v2.

~~The infrastructure hosting the app serving docs at apidocs.cloudfoundry.org is expected to go down imminently, so this change is needed to avoid dead links.~~
`apidocs.cloudfoundry.org` has been converted to a redirect to `v3-apidocs.cloudfoundry.org`, so this change is needed to avoid incorrect links

See capi-release PRs [#440](https://github.com/cloudfoundry/capi-release/pull/440) and [#441](https://github.com/cloudfoundry/capi-release/pull/441)